### PR TITLE
Fix pluralisation typo in routing.md [ci skip]

### DIFF
--- a/guides/source/routing.md
+++ b/guides/source/routing.md
@@ -34,7 +34,7 @@ GET /users/17
 If the first matching route is:
 
 ```ruby
-get "/users/:id", to: "user#show"
+get "/users/:id", to: "users#show"
 ```
 
 The request is matched to the `UsersController` class's `show` action with `{ id: '17' }` in the `params` hash.


### PR DESCRIPTION
Controller name should be pluralised

### Motivation / Background

Just fixing a small typo regarding pluralisation of the controller name in the routes file.

